### PR TITLE
add scripts to add only keycloak DS (for migration)

### DIFF
--- a/databases/h2-add-kc-ds-wildfly.cli
+++ b/databases/h2-add-kc-ds-wildfly.cli
@@ -1,0 +1,9 @@
+# $WILDFLY_HOME/bin/jboss-cli.sh --file=/path/to/this/file.
+connect
+batch
+
+## Add Keycloak Datasource
+data-source add --name=KeycloakDS --driver-name=h2 --jndi-name=java:jboss/datasources/KeycloakDS --connection-url="jdbc:h2:${jboss.server.data.dir}/keycloak;DB_CLOSE_DELAY=-1" --user-name=sa --password=sa --use-ccm=true --enabled=true
+
+run-batch
+#:reload

--- a/databases/mysql-add-kc-ds-wildfly.cli
+++ b/databases/mysql-add-kc-ds-wildfly.cli
@@ -1,0 +1,9 @@
+# $WILDFLY_HOME/bin/jboss-cli.sh --file=/path/to/this/file.
+connect
+batch
+
+## Add Keycloak Datasource
+data-source add --name=KeycloakDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/KeycloakDS --connection-url="jdbc:mysql://localhost:3306/keycloak?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+
+run-batch
+#:reload

--- a/databases/postgresql-add-kc-ds-wildfly.cli
+++ b/databases/postgresql-add-kc-ds-wildfly.cli
@@ -1,0 +1,9 @@
+# $WILDFLY_HOME/bin/jboss-cli.sh --file=/path/to/this/file.
+connect
+batch
+
+## Add Keycloak Datasource
+data-source add --name=KeycloakDS --driver-name=psqlup --jndi-name=java:jboss/datasources/KeycloakDS --connection-url=jdbc:postgresql://localhost:5432/keycloak --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+
+run-batch
+#:reload


### PR DESCRIPTION
Keycloak migration would have to follow a different path (something manually or provided by KC itself) but at least we can provide these scripts to add the KeyCloak datasources (the original script fails with a duplicate error since it also contain the unifiedpush datasource)
