### PR TITLE
Migrator null constraints

### DIFF
--- a/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-10-reenable-constraints.xml
+++ b/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-10-reenable-constraints.xml
@@ -94,4 +94,7 @@
     <changeSet author="danbev" id="1436957323846-14">
         <addNotNullConstraint tableName="variant_metric_info" columnName="receivers" defaultNullValue="0"/>
     </changeSet>
+    <changeSet author="danbev" id="1436957323846-15">
+        <addNotNullConstraint tableName="variant_metric_info" columnName="variant_open_counter" defaultNullValue="0"/>
+    </changeSet>
 </databaseChangeLog>

--- a/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-10-reenable-constraints.xml
+++ b/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-10-reenable-constraints.xml
@@ -97,4 +97,7 @@
     <changeSet author="danbev" id="1436957323846-15">
         <addNotNullConstraint tableName="variant_metric_info" columnName="variant_open_counter" defaultNullValue="0"/>
     </changeSet>
+    <changeSet author="danbev" id="1436957323846-16">
+        <addNotNullConstraint tableName="variant_metric_info" columnName="total_batches" defaultNullValue="0"/>
+    </changeSet>
 </databaseChangeLog>

--- a/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-10-reenable-constraints.xml
+++ b/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-10-reenable-constraints.xml
@@ -103,4 +103,7 @@
     <changeSet author="danbev" id="1436957323846-17">
         <addNotNullConstraint tableName="variant_metric_info" columnName="total_batches" defaultNullValue="0"/>
     </changeSet>
+    <changeSet author="danbev" id="1436957323846-18">
+        <addNotNullConstraint tableName="variant_metric_info" columnName="served_batches" defaultNullValue="0"/>
+    </changeSet>
 </databaseChangeLog>

--- a/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-10-reenable-constraints.xml
+++ b/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-10-reenable-constraints.xml
@@ -88,4 +88,7 @@
     <changeSet author="danbev" id="1436957323846-12">
         <addNotNullConstraint tableName="push_message_info" columnName="served_variants" defaultNullValue="0"/>
     </changeSet>
+    <changeSet author="danbev" id="1436957323846-13">
+        <addNotNullConstraint tableName="push_message_info" columnName="app_open_counter" defaultNullValue="0"/>
+    </changeSet>
 </databaseChangeLog>

--- a/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-10-reenable-constraints.xml
+++ b/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-10-reenable-constraints.xml
@@ -82,4 +82,7 @@
                                  initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION"
                                  referencedColumnNames="api_key" referencedTableName="variant"/>
     </changeSet>
+    <changeSet author="danbev" id="1436957323846-11">
+        <addNotNullConstraint tableName="push_message_info" columnName="total_variants" defaultNullValue="0"/>
+    </changeSet>
 </databaseChangeLog>

--- a/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-10-reenable-constraints.xml
+++ b/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-10-reenable-constraints.xml
@@ -85,4 +85,7 @@
     <changeSet author="danbev" id="1436957323846-11">
         <addNotNullConstraint tableName="push_message_info" columnName="total_variants" defaultNullValue="0"/>
     </changeSet>
+    <changeSet author="danbev" id="1436957323846-12">
+        <addNotNullConstraint tableName="push_message_info" columnName="served_variants" defaultNullValue="0"/>
+    </changeSet>
 </databaseChangeLog>

--- a/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-10-reenable-constraints.xml
+++ b/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-10-reenable-constraints.xml
@@ -91,4 +91,7 @@
     <changeSet author="danbev" id="1436957323846-13">
         <addNotNullConstraint tableName="push_message_info" columnName="app_open_counter" defaultNullValue="0"/>
     </changeSet>
+    <changeSet author="danbev" id="1436957323846-14">
+        <addNotNullConstraint tableName="variant_metric_info" columnName="receivers" defaultNullValue="0"/>
+    </changeSet>
 </databaseChangeLog>

--- a/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-10-reenable-constraints.xml
+++ b/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-10-reenable-constraints.xml
@@ -92,12 +92,15 @@
         <addNotNullConstraint tableName="push_message_info" columnName="app_open_counter" defaultNullValue="0"/>
     </changeSet>
     <changeSet author="danbev" id="1436957323846-14">
-        <addNotNullConstraint tableName="variant_metric_info" columnName="receivers" defaultNullValue="0"/>
+        <addNotNullConstraint tableName="push_message_info" columnName="total_receivers" defaultNullValue="0"/>
     </changeSet>
     <changeSet author="danbev" id="1436957323846-15">
-        <addNotNullConstraint tableName="variant_metric_info" columnName="variant_open_counter" defaultNullValue="0"/>
+        <addNotNullConstraint tableName="variant_metric_info" columnName="receivers" defaultNullValue="0"/>
     </changeSet>
     <changeSet author="danbev" id="1436957323846-16">
+        <addNotNullConstraint tableName="variant_metric_info" columnName="variant_open_counter" defaultNullValue="0"/>
+    </changeSet>
+    <changeSet author="danbev" id="1436957323846-17">
         <addNotNullConstraint tableName="variant_metric_info" columnName="total_batches" defaultNullValue="0"/>
     </changeSet>
 </databaseChangeLog>

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.java
@@ -39,7 +39,7 @@ public class PushMessageInformation extends BaseModel {
     private Date submitDate = new Date();
     private long totalReceivers;
 
-    private long appOpenCounter;
+    private Long appOpenCounter = 0L;
     private Date firstOpenDate;
     private Date lastOpenDate;
 
@@ -140,11 +140,11 @@ public class PushMessageInformation extends BaseModel {
      *
      * @return the number of time this Push Application was opened after a Push Notification
      */
-    public long getAppOpenCounter() {
+    public Long getAppOpenCounter() {
         return appOpenCounter;
     }
 
-    public void setAppOpenCounter(long appOpenCounter) {
+    public void setAppOpenCounter(Long appOpenCounter) {
         this.appOpenCounter = appOpenCounter;
     }
 

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.java
@@ -37,7 +37,7 @@ public class PushMessageInformation extends BaseModel {
     private String clientIdentifier;
 
     private Date submitDate = new Date();
-    private long totalReceivers;
+    private Long totalReceivers = 0L;
 
     private Long appOpenCounter = 0L;
     private Date firstOpenDate;
@@ -127,11 +127,11 @@ public class PushMessageInformation extends BaseModel {
      *
      * @return the total of active tokens that received this Push Message
      */
-    public long getTotalReceivers() {
+    public Long getTotalReceivers() {
         return totalReceivers;
     }
 
-    public void setTotalReceivers(long totalReceivers) {
+    public void setTotalReceivers(Long totalReceivers) {
         this.totalReceivers = totalReceivers;
     }
 

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.java
@@ -43,7 +43,7 @@ public class PushMessageInformation extends BaseModel {
     private Date firstOpenDate;
     private Date lastOpenDate;
 
-    private int servedVariants;
+    private Integer servedVariants = 0;
     private Integer totalVariants = 0;
 
     private Set<VariantMetricInformation> variantInformations = new HashSet<VariantMetricInformation>();
@@ -188,11 +188,11 @@ public class PushMessageInformation extends BaseModel {
      *
      * @return number of variants that were fully processed (all batches were served)
      */
-    public int getServedVariants() {
+    public Integer getServedVariants() {
         return servedVariants;
     }
 
-    public void setServedVariants(int servedVariants) {
+    public void setServedVariants(Integer servedVariants) {
         this.servedVariants = servedVariants;
     }
 

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.java
@@ -44,7 +44,7 @@ public class PushMessageInformation extends BaseModel {
     private Date lastOpenDate;
 
     private int servedVariants;
-    private int totalVariants;
+    private Integer totalVariants = 0;
 
     private Set<VariantMetricInformation> variantInformations = new HashSet<VariantMetricInformation>();
 
@@ -203,11 +203,11 @@ public class PushMessageInformation extends BaseModel {
      *
      * @return total number of variants to be served for the given push message.
      */
-    public int getTotalVariants() {
+    public Integer getTotalVariants() {
         return totalVariants;
     }
 
-    public void setTotalVariants(int totalVariants) {
+    public void setTotalVariants(Integer totalVariants) {
         this.totalVariants = totalVariants;
     }
 

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.java
@@ -34,7 +34,7 @@ public class VariantMetricInformation extends BaseModel {
     private Boolean deliveryStatus = Boolean.FALSE;
     private String reason;
     private Long variantOpenCounter = 0L;
-    private int servedBatches = 0;
+    private Integer servedBatches = 0;
     private Integer totalBatches = 0;
 
     @JsonIgnore
@@ -127,11 +127,11 @@ public class VariantMetricInformation extends BaseModel {
      *
      * @return number of device token batches that were fully processed.
      */
-    public int getServedBatches() {
+    public Integer getServedBatches() {
         return servedBatches;
     }
 
-    public void setServedBatches(int servedBatches) {
+    public void setServedBatches(Integer servedBatches) {
         this.servedBatches = servedBatches;
     }
 

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.java
@@ -30,7 +30,7 @@ public class VariantMetricInformation extends BaseModel {
 
     @NotNull
     private String variantID;
-    private long receivers;
+    private Long receivers = 0L;
     private Boolean deliveryStatus = Boolean.FALSE;
     private String reason;
     private long variantOpenCounter;
@@ -61,11 +61,11 @@ public class VariantMetricInformation extends BaseModel {
      *
      * @return number of receivers
      */
-    public long getReceivers() {
+    public Long getReceivers() {
         return receivers;
     }
 
-    public void setReceivers(long receivers) {
+    public void setReceivers(Long receivers) {
         this.receivers = receivers;
     }
 

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.java
@@ -33,7 +33,7 @@ public class VariantMetricInformation extends BaseModel {
     private Long receivers = 0L;
     private Boolean deliveryStatus = Boolean.FALSE;
     private String reason;
-    private long variantOpenCounter;
+    private Long variantOpenCounter = 0L;
     private int servedBatches = 0;
     private int totalBatches = 0;
 
@@ -108,11 +108,11 @@ public class VariantMetricInformation extends BaseModel {
      *
      * @return long , the times this variant has been opened after a Push Notification
      */
-    public long getVariantOpenCounter() {
+    public Long getVariantOpenCounter() {
         return variantOpenCounter;
     }
 
-    public void setVariantOpenCounter(long variantOpenCounter) {
+    public void setVariantOpenCounter(Long variantOpenCounter) {
         this.variantOpenCounter = variantOpenCounter;
     }
 

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.java
@@ -35,7 +35,7 @@ public class VariantMetricInformation extends BaseModel {
     private String reason;
     private Long variantOpenCounter = 0L;
     private int servedBatches = 0;
-    private int totalBatches = 0;
+    private Integer totalBatches = 0;
 
     @JsonIgnore
     private PushMessageInformation pushMessageInformation;
@@ -142,11 +142,11 @@ public class VariantMetricInformation extends BaseModel {
      *
      * @return total number of device token batches that were loaded by the TokenLoader.
      */
-    public int getTotalBatches() {
+    public Integer getTotalBatches() {
         return totalBatches;
     }
 
-    public void setTotalBatches(int totalBatches) {
+    public void setTotalBatches(Integer totalBatches) {
         this.totalBatches = totalBatches;
     }
 }

--- a/model/api/src/test/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformationTest.java
+++ b/model/api/src/test/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformationTest.java
@@ -49,13 +49,13 @@ public class PushMessageInformationTest {
         // two involved variants:
         VariantMetricInformation variantInfo1 = new VariantMetricInformation();
         variantInfo1.setVariantID("345");
-        variantInfo1.setReceivers(500);
+        variantInfo1.setReceivers(Long.valueOf(500));
         variantInfo1.setDeliveryStatus(Boolean.FALSE);
         variantInfo1.setVariantOpenCounter(1);
 
         VariantMetricInformation variantInfo2 = new VariantMetricInformation();
         variantInfo2.setVariantID("678");
-        variantInfo2.setReceivers(100);
+        variantInfo2.setReceivers(Long.valueOf(100));
         variantInfo2.setDeliveryStatus(Boolean.TRUE);
         variantInfo1.setVariantOpenCounter(2);
 

--- a/model/api/src/test/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformationTest.java
+++ b/model/api/src/test/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformationTest.java
@@ -41,7 +41,7 @@ public class PushMessageInformationTest {
         pushMessageInformation.setRawJsonMessage("{\"data\" : \"something\"}");
         pushMessageInformation.setIpAddress("127.0.0.1");
         pushMessageInformation.setClientIdentifier("Java Sender Client");
-        pushMessageInformation.setAppOpenCounter(1);
+        pushMessageInformation.setAppOpenCounter(Long.valueOf(1));
         pushMessageInformation.setFirstOpenDate(openAppDate);
         pushMessageInformation.setLastOpenDate(lastOpenDate);
 

--- a/model/api/src/test/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformationTest.java
+++ b/model/api/src/test/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformationTest.java
@@ -51,13 +51,13 @@ public class PushMessageInformationTest {
         variantInfo1.setVariantID("345");
         variantInfo1.setReceivers(Long.valueOf(500));
         variantInfo1.setDeliveryStatus(Boolean.FALSE);
-        variantInfo1.setVariantOpenCounter(1);
+        variantInfo1.setVariantOpenCounter(Long.valueOf(1));
 
         VariantMetricInformation variantInfo2 = new VariantMetricInformation();
         variantInfo2.setVariantID("678");
         variantInfo2.setReceivers(Long.valueOf(100));
         variantInfo2.setDeliveryStatus(Boolean.TRUE);
-        variantInfo1.setVariantOpenCounter(2);
+        variantInfo1.setVariantOpenCounter(Long.valueOf(2));
 
         // add the variant metadata:
         pushMessageInformation.getVariantInformations().add(variantInfo1);

--- a/model/jpa/src/main/resources/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.hbm.xml
+++ b/model/jpa/src/main/resources/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.hbm.xml
@@ -10,7 +10,7 @@
         <property name="variantID" type="java.lang.String" index="variant_idx">
             <column name="variant_id" not-null="true"/>
         </property>
-        <property name="receivers" type="long">
+        <property name="receivers" type="java.lang.Long">
             <column name="receivers" />
         </property>
         <property name="deliveryStatus" type="java.lang.Boolean">

--- a/model/jpa/src/main/resources/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.hbm.xml
+++ b/model/jpa/src/main/resources/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.hbm.xml
@@ -19,7 +19,7 @@
         <property name="reason" type="java.lang.String">
             <column name="reason" />
         </property>
-        <property name="variantOpenCounter" type="long">
+        <property name="variantOpenCounter" type="java.lang.Long">
             <column name="variant_open_counter" />
         </property>
         <property name="servedBatches" type="int">

--- a/model/jpa/src/main/resources/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.hbm.xml
+++ b/model/jpa/src/main/resources/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.hbm.xml
@@ -25,7 +25,7 @@
         <property name="servedBatches" type="int">
             <column name="served_batches" />
         </property>
-        <property name="totalBatches" type="int">
+        <property name="totalBatches" type="java.lang.Integer">
             <column name="total_batches" />
         </property>
         <many-to-one name="pushMessageInformation" class="org.jboss.aerogear.unifiedpush.api.PushMessageInformation" fetch="join">

--- a/model/jpa/src/main/resources/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.hbm.xml
+++ b/model/jpa/src/main/resources/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.hbm.xml
@@ -22,7 +22,7 @@
         <property name="variantOpenCounter" type="java.lang.Long">
             <column name="variant_open_counter" />
         </property>
-        <property name="servedBatches" type="int">
+        <property name="servedBatches" type="java.lang.Integer">
             <column name="served_batches" />
         </property>
         <property name="totalBatches" type="java.lang.Integer">

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationDispatcher.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationDispatcher.java
@@ -108,7 +108,7 @@ public class NotificationDispatcher {
         final VariantMetricInformation variantMetricInformation = new VariantMetricInformation();
         variantMetricInformation.setPushMessageInformation(pushMessageInformation);
         variantMetricInformation.setVariantID(variantID);
-        variantMetricInformation.setReceivers(receivers);
+        variantMetricInformation.setReceivers(Long.valueOf(receivers));
         variantMetricInformation.setDeliveryStatus(deliveryStatus);
         variantMetricInformation.setReason(reason);
         variantMetricInformation.setServedBatches(1);

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/TestMetricsCollector.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/TestMetricsCollector.java
@@ -107,9 +107,9 @@ public class TestMetricsCollector extends AbstractJMSTest {
 
         // then
         assertEquals(2, pushMetric.getServedVariants().intValue());
-        assertEquals(2, variant1Metric1.getServedBatches());
+        assertEquals(2, variant1Metric1.getServedBatches().intValue());
         assertEquals(2, variant1Metric1.getTotalBatches().intValue());
-        assertEquals(1, variant2Metric1.getServedBatches());
+        assertEquals(1, variant2Metric1.getServedBatches().intValue());
         assertEquals(1, variant2Metric1.getTotalBatches().intValue());
         assertNull(receive(batchLoadedQueue, variantID1));
         assertNull(receive(allBatchesLoaded, variantID1));

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/TestMetricsCollector.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/TestMetricsCollector.java
@@ -108,9 +108,9 @@ public class TestMetricsCollector extends AbstractJMSTest {
         // then
         assertEquals(2, pushMetric.getServedVariants().intValue());
         assertEquals(2, variant1Metric1.getServedBatches());
-        assertEquals(2, variant1Metric1.getTotalBatches());
+        assertEquals(2, variant1Metric1.getTotalBatches().intValue());
         assertEquals(1, variant2Metric1.getServedBatches());
-        assertEquals(1, variant2Metric1.getTotalBatches());
+        assertEquals(1, variant2Metric1.getTotalBatches().intValue());
         assertNull(receive(batchLoadedQueue, variantID1));
         assertNull(receive(allBatchesLoaded, variantID1));
         assertNull(receive(batchLoadedQueue, variantID2));

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/TestMetricsCollector.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/TestMetricsCollector.java
@@ -106,7 +106,7 @@ public class TestMetricsCollector extends AbstractJMSTest {
         variantsCompleted.await(1, TimeUnit.SECONDS);
 
         // then
-        assertEquals(2, pushMetric.getServedVariants());
+        assertEquals(2, pushMetric.getServedVariants().intValue());
         assertEquals(2, variant1Metric1.getServedBatches());
         assertEquals(2, variant1Metric1.getTotalBatches());
         assertEquals(1, variant2Metric1.getServedBatches());


### PR DESCRIPTION
Currently when a database is migrated from a version there might be fields in the database that are empty (null), causing JPA to try to set the entity property to null. There are several primitive fields in our database model which will cause JPA to throw an exception stating that it is trying to set the value to null. 

These commits add constraints to the tables in question and also update the java object model to match the database model so wrapper classes are used for the types instead of primitive values.
